### PR TITLE
Избегаем отображения прогресс-баров поверх ChangeLog.

### DIFF
--- a/Motocitizen/src/motocitizen/app/mc/gcm/MCGCMRegistration.java
+++ b/Motocitizen/src/motocitizen/app/mc/gcm/MCGCMRegistration.java
@@ -135,7 +135,7 @@ public class MCGCMRegistration {
             prefs.setGCMRegistrationCode(regId);
             JsonRequest request = new JsonRequest("mcaccidents", "registerGCM", createPOST(regId), "", true);
             if (request != null) {
-                (new registerGCMRequest(context)).execute(request);
+                (new registerGCMRequest(context, !Startup.isChangeLogDlgShowing())).execute(request);
             }
         } else {
             Toast.makeText(context, Startup.context.getString(R.string.inet_not_available), Toast.LENGTH_LONG).show();

--- a/Motocitizen/src/motocitizen/network/HttpClient.java
+++ b/Motocitizen/src/motocitizen/network/HttpClient.java
@@ -31,10 +31,18 @@ public class HttpClient extends AsyncTask<JsonRequest, Void, JSONObject> {
     ProgressDialog dialog;
     private final String info;
     private final Context context;
+    private final boolean isCreateDialog;
 
     public HttpClient(Context context, String info) {
         this.info = info;
         this.context = context;
+        this.isCreateDialog = true;
+    }
+
+    public HttpClient(Context context, String info, boolean isCreateDialog) {
+        this.info = info;
+        this.context = context;
+        this.isCreateDialog = isCreateDialog;
     }
 
     private final static String CHARSET = "UTF-8";
@@ -43,7 +51,7 @@ public class HttpClient extends AsyncTask<JsonRequest, Void, JSONObject> {
     private String method = null;
 
     protected void onPreExecute() {
-        if (!info.equals("")) {
+        if (isCreateDialog && !info.equals("")) {
             Runnable execute = new Runnable() {
                 @Override
                 public void run() {

--- a/Motocitizen/src/motocitizen/network/IncidentRequest.java
+++ b/Motocitizen/src/motocitizen/network/IncidentRequest.java
@@ -10,8 +10,8 @@ import motocitizen.startup.Startup;
 
 public class IncidentRequest extends HttpClient {
 
-    public IncidentRequest(Context context) {
-        super(context, context.getString(R.string.request_get_incidents));
+    public IncidentRequest(Context context, boolean isCreateDialog) {
+        super(context, context.getString(R.string.request_get_incidents), isCreateDialog);
     }
 
     // как только получили ответ от сервера, выключаем ProgressBar

--- a/Motocitizen/src/motocitizen/network/registerGCMRequest.java
+++ b/Motocitizen/src/motocitizen/network/registerGCMRequest.java
@@ -10,8 +10,8 @@ import motocitizen.main.R;
  * Created by elagin on 03.04.15.
  */
 public class registerGCMRequest extends HttpClient {
-    public registerGCMRequest(Context context) {
-        super(context, context.getString(R.string.request_google_gcm));
+    public registerGCMRequest(Context context, boolean isCreateDialog) {
+        super(context, context.getString(R.string.request_google_gcm), isCreateDialog);
     }
 
     protected void onPostExecute(JSONObject result) {

--- a/Motocitizen/src/motocitizen/startup/ChangeLog.java
+++ b/Motocitizen/src/motocitizen/startup/ChangeLog.java
@@ -21,7 +21,6 @@ import motocitizen.main.R;
 
 public class ChangeLog {
 
-
     private static final String EOCL = "END_OF_CHANGE_LOG";
     private static String lastVersion;
     private static StringBuffer sb = null;
@@ -42,8 +41,6 @@ public class ChangeLog {
                                         int which) {
                     }
                 });
-
-
         return builder.create();
     }
 

--- a/Motocitizen/src/motocitizen/startup/Startup.java
+++ b/Motocitizen/src/motocitizen/startup/Startup.java
@@ -1,5 +1,6 @@
 package motocitizen.startup;
 
+import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
@@ -63,6 +64,8 @@ public class Startup extends ActionBarActivity implements View.OnClickListener {
 
     private static ActionBar actionBar;
 
+    private static AlertDialog changeLogDlg = null;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -117,8 +120,8 @@ public class Startup extends ActionBarActivity implements View.OnClickListener {
             version = getString(R.string.unknown_code_version);
         }
         if(!prefs.getCurrentVersion().equals(version)){
-
-            ChangeLog.getDialog(this, true).show();
+            changeLogDlg = ChangeLog.getDialog(this, true);
+            changeLogDlg.show();
         }
         prefs.setCurrentVersion(version);
     }
@@ -150,7 +153,7 @@ public class Startup extends ActionBarActivity implements View.OnClickListener {
         if (isOnline()) {
             JsonRequest request = MCAccidents.getLoadPointsRequest();
             if (request != null) {
-                (new IncidentRequest(this)).execute(request);
+                (new IncidentRequest(this, !isChangeLogDlgShowing())).execute(request);
             }
             catchIntent(intent);
         } else {
@@ -312,7 +315,7 @@ public class Startup extends ActionBarActivity implements View.OnClickListener {
                 if (Startup.isOnline()) {
                     JsonRequest request = MCAccidents.getLoadPointsRequest();
                     if (request != null) {
-                        (new IncidentRequest(context)).execute(request);
+                        (new IncidentRequest(context, true)).execute(request);
                     }
                 } else {
                     Toast.makeText(context, Startup.context.getString(R.string.inet_not_available), Toast.LENGTH_LONG).show();
@@ -346,5 +349,9 @@ public class Startup extends ActionBarActivity implements View.OnClickListener {
                 return true;
         }
         return false;
+    }
+
+    public static boolean isChangeLogDlgShowing() {
+        return (changeLogDlg != null && changeLogDlg.isShowing());
     }
 }


### PR DESCRIPTION
Но есть побочный эффект: если юзер закроет этот диалог до окончания загрузки инцидентов, будет наблюдать пустой список.