### PR TITLE
Обработка ситуаций, когда сервер может вернуть:

### DIFF
--- a/Motocitizen/src/motocitizen/Activity/DetailVolunteersFragment.java
+++ b/Motocitizen/src/motocitizen/Activity/DetailVolunteersFragment.java
@@ -202,6 +202,7 @@ public class DetailVolunteersFragment extends AccidentDetailsFragments {
                 }
             } catch (JSONException e) {
                 e.printStackTrace();
+                Toast.makeText(context, result.toString(), Toast.LENGTH_LONG).show();
             }
         }
     }

--- a/Motocitizen/src/motocitizen/network/requests/HTTPClient.java
+++ b/Motocitizen/src/motocitizen/network/requests/HTTPClient.java
@@ -139,7 +139,19 @@ public class HTTPClient extends AsyncTask<Map<String, String>, Integer, JSONObje
             reader = new JSONObject(response.toString());
         } catch (JSONException e) {
             e.printStackTrace();
-            reader = new JSONObject();
+            try {
+                reader = new JSONObject(response.toString().replace("\\", "").replace("\"", ""));
+            } catch (JSONException e1) {
+                e1.printStackTrace();
+                String fakeAnswer = "{ error : unknown }";
+                try {
+                    reader = new JSONObject(fakeAnswer);
+                } catch (JSONException e2) {
+                    //Абсолютно маловероятно
+                    e2.printStackTrace();
+                    reader = new JSONObject();
+                }
+            }
         }
         Log.d("JSON RESPONSE", reader.toString());
         return reader;


### PR DESCRIPTION
* ошибку формата {\"error\":\"wrong_method\"} - очищаем лишние символы, чтобы создался JSONObject
* что попало - создаем { error : unknown }

Пример отображения ошибки пользователю на примере onway.

Что лучше, показать пользователю то, что отдал сервер или "ошибка при разборе ответа от сервера"? Во втором случае надо логи сервера смотреть. Зато в пером юзер видет как-то осмысленный текст.